### PR TITLE
Go oracle is renamed to guru.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ export GOPATH=`*path_to_workspace*`/bin
 
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
-Install Go Oracle:
+Install Go Guru:
 
-go get golang.org/x/tools/cmd/oracle
+go get golang.org/x/tools/cmd/guru
 
 Running gopherlyzer:
 

--- a/oracleAPI/oracler.go
+++ b/oracleAPI/oracler.go
@@ -47,11 +47,11 @@ func New(oraclepath, filepath, rootpath string) *OracleAPI {
 }
 
 func (o *OracleAPI) GetPeers(format string, charpos int) PeersMode {
-	cmd := exec.Command(o.OraclePath, fmt.Sprintf("-format=%v", format),
-		fmt.Sprintf("-pos=%v:#%v", o.FilePath, charpos), "peers",
-		o.RootPath)
+	cmd := exec.Command(o.OraclePath,
+		fmt.Sprintf("-%v", format), fmt.Sprintf("-scope=%s", o.RootPath),
+		"peers",
+		fmt.Sprintf("%v:#%v", o.FilePath, charpos))
 	cmd.Stderr = os.Stdout
-    
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -123,13 +123,14 @@ func (o *OracleAPI) FindDefinition(line int64) int64 {
 }
 
 func (o *OracleAPI) FindVariableName(line int64) string {
-    
-    i := o.GetOffset(line, 0)
-    j := o.FindDefinition(line)
-    
-    cmd := exec.Command(o.OraclePath, "-format=json",
-		fmt.Sprintf("-pos=%v:#%v,#%v", o.FilePath, i,j), "definition",
-		o.RootPath)
+
+	i := o.GetOffset(line, 0)
+	j := o.FindDefinition(line)
+
+	cmd := exec.Command(o.OraclePath,
+		"-json", fmt.Sprintf("-scope=%v", o.RootPath),
+		"definition",
+		fmt.Sprintf("%v:#%v,#%v", o.FilePath, i, j))
 	cmd.Stderr = os.Stdout
 	out, err := cmd.Output()
 	if err != nil {

--- a/simplifier/simplifiy.go
+++ b/simplifier/simplifiy.go
@@ -159,7 +159,7 @@ func (s *Simplifier) handleUnaryExpr(n *ast.UnaryExpr) (bool, Operation) {
 	var resOps Operation
 	if n.Op == token.ARROW {
 		pos := s.FSet.Position(n.OpPos).Offset
-		oraclePath := "oracle"
+		oraclePath := "guru"
 
 		oracle := oracler.New(oraclePath, s.Path, "./"+filepath.Dir(s.Path))
 
@@ -181,7 +181,7 @@ func (s *Simplifier) handleUnaryExpr(n *ast.UnaryExpr) (bool, Operation) {
 
 func (s *Simplifier) handleSend(n *ast.SendStmt) (bool, Operation) {
 	pos := s.FSet.Position(n.Arrow).Offset
-	oraclePath := "oracle"
+	oraclePath := "guru"
 
 	oracle := oracler.New(oraclePath, s.Path, "./"+filepath.Dir(s.Path))
 	p := oracle.GetPeers("json", pos)


### PR DESCRIPTION
As of 12 Feb 2016, the go oracle tool is renamed to guru, see [CL](https://go-review.googlesource.com/c/19475) for details.

This PR maintains the same behaviour of the tool as previous version, but updates:
- The name and arguments of the command line tool
- The install instructions in `README.md`